### PR TITLE
Added Server Application for the gRPC Fewer Service

### DIFF
--- a/client/internal/client_loggers.go
+++ b/client/internal/client_loggers.go
@@ -93,6 +93,9 @@ func (clop *ClientLoggingObjectPROD) Close() {
 // Definition of a development-level client activity logger that logs both on the 
 //   terminal/standard output and a file.
 type ClientLoggingObjectDEV struct {
+	// Inherit the ClientLoggingObjectPROD methods, because they satify the ClientLogger
+	//   interface
+	ClientLoggingObjectPROD
 	// Log only current session activity on standard output
 	terminalLogger   log.Logger
 	// Log all client sessions' history on a file
@@ -139,28 +142,3 @@ func (clod *ClientLoggingObjectDEV) ClientLogDebug(key, value, message string) {
 	level.Debug(clod.clientFileLogger).Log(key, value, "message", message)
 }
 
-// Method of the ClientLoggingObjectDEV that is used for simultaneously logging INFO-level
-//   activity on both the terminal and client log file.
-func (clod *ClientLoggingObjectDEV) ClientLogInfo(key, value, message string) {
-	go level.Info(clod.terminalLogger).Log(key, value, "message", message)
-	level.Info(clod.clientFileLogger).Log(key, value, "message", message)
-}
-
-// Method of the ClientLoggingObjectDEV that is used for simultaneously logging WARN-level 
-//   activity on both the terminal and client log file.
-func (clod *ClientLoggingObjectDEV) ClientLogWarn(key, value, message string) {
-	go level.Warn(clod.terminalLogger).Log(key, value, "message", message)
-	level.Warn(clod.clientFileLogger).Log(key, value, "message", message)
-}
-
-// Method of the ClientLoggingObjectDEV that is used for simultaneously logging ERROR-level 
-//   activity on both the terminal and client log file.
-func (clod *ClientLoggingObjectDEV) ClientLogError(key, value, message string) {
-	go level.Error(clod.terminalLogger).Log(key, value, "error", message)
-	level.Error(clod.clientFileLogger).Log(key, value, "error", message)
-}
-
-// Method of the ClientLoggingObjectDEV that is used for closing the client log file properly.
-func (clod *ClientLoggingObjectDEV) Close() {
-	clod.clientLogFile.Close()
-}

--- a/server/app.go
+++ b/server/app.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/astronomical3/fewer_grpc/server/internal"
+)
+
+// Provide a name of the production-level or development-level server activity log file.
+//   The filename is relative to the fewer_grpc/server/serverlogs/ directory path.
+const serverLogFilename = "server.log"
+
+// Definition of the --address flag of the 'go run [fewer_grpc/server/]app.go' command.
+var address = flag.String("address", "localhost", "address of server to serve on")
+
+// Definition of the --port flag of the 'go run [fewer_grpc/server/]app.go' command.
+var port = flag.Int("port", 50051, "port of server to serve on")
+
+// Definition of the --prod flag of the 'go run [fewer_grpc/server/]app.go' command.
+var prod = flag.Bool("prod", true, "indicates whether server is production server or development server")
+
+func main() {
+	// Create a listener, lis, that will listen to requests to the address and port
+	//   provided by the 'go run' command flags.
+	addrString := fmt.Sprintf("%s:%d", *address, *port)
+	lis, err := net.Listen("tcp", addrString)
+	if err != nil {
+		log.Fatalf("fewer_grpc/server/app.go: net.Listen failed to listen: %v", err)
+	}
+
+	// Create a new GeneralFewerServer object.
+	genServer := internal.NewGeneralFewerServer(serverLogFilename, lis, *prod)
+
+	// Have the GeneralFewerServer object serve clients.  This method also handles
+	//   shutdowns or server failures.
+	genServer.ListenAndServe()
+}

--- a/server/internal/general_server.go
+++ b/server/internal/general_server.go
@@ -1,0 +1,110 @@
+package internal
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	pb "github.com/astronomical3/fewer_grpc/fewer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+//*************************************************************************
+// Definition of the general gRPC server that will host the Fewer Service.
+type GeneralFewerServer struct {
+	// Added upon creation of the server
+	listener     net.Listener
+
+	// Received later on in the setup.
+	grpcServer   *grpc.Server
+	serverLogger ServerLogger
+	srv          *FewerService
+}
+
+// Create a new general gRPC server, and create a new server logging object depending on whether the server 
+//   will be production or development/test.
+func NewGeneralFewerServer(serverLogFilename string, lis net.Listener, isProd bool) *GeneralFewerServer {
+	// Obtain a new general gRPC server
+	grpcServer := grpc.NewServer()
+
+	// Obtain a new server logging object depending on whether the server will be production- or 
+	//   development/test-grade.
+	var serverLogger ServerLogger
+	if isProd {
+		serverLogger = NewServerLoggingObjectPROD(serverLogFilename)
+	} else {
+		serverLogger = NewServerLoggingObjectDEV(serverLogFilename)
+	}
+
+	// Create a new instance of the Fewer Service.
+	srv := NewFewerService(serverLogger)
+
+	return &GeneralFewerServer{
+		listener:     lis,
+		grpcServer:   grpcServer,
+		serverLogger: serverLogger,
+		srv:          srv,
+	}
+}
+
+// Method of the GeneralFewerServer that is used for registering its new Fewer Service instance to its general
+//   gRPC server, registering a gRPC reflection service (for providing RPC and other useful information about
+//   the Fewer Service to tools such as grpcurl), and then setting up a channel to listen to OS termination or
+//   interruption signals and a goroutine for serving Fewer Service clients.
+func (fs *GeneralFewerServer) ListenAndServe() {
+	// Register the Fewer Service instance and an instance of the gRPC reflection service to the gRPC server.
+	pb.RegisterFewerServiceServer(fs.grpcServer, fs.srv)
+	reflection.Register(fs.grpcServer)
+
+	// Create a channel, sigChan, that will listen to an OS termination or interruption signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Have the server listen to all FewerService-specific requests.
+	go func() {
+		fs.serverLogger.ServerLogInfo(
+			"method",
+			"GeneralFewerServer_ListenAndServe",
+			fmt.Sprintf("FewerServer listening on address %v", fs.listener.Addr()),
+		)
+		if err := fs.grpcServer.Serve(fs.listener); err != nil {
+			fs.serverLogger.ServerLogError(
+				"method",
+				"GeneralFewerServer_ListenAndServe",
+				fmt.Sprintf("Failed to serve via grpcServer.Serve() method: %v", err),
+			)
+			fs.serverLogger.ServerLogError(
+				"method",
+				"GeneralFewerServer_ListenAndServe",
+				"Closing server log, returning exit code 1...",
+			)
+			fs.serverLogger.Close()
+			fs.listener.Close()
+			os.Exit(1)
+		}
+	}()
+
+	// Block until an interruption/termination signal is received.
+	sig := <-sigChan
+	fs.serverLogger.ServerLogInfo(
+		"method",
+		"GeneralFewerServer_ListenAndServe",
+		fmt.Sprintf("Received signal (%s), starting graceful shutdown...", sig.String()),
+	)
+	fs.shutdown()
+}
+
+// Internal method of the GeneralFewerServer for ensuring graceful stop of
+//  gRPC server when an OS termination/interruption signal is issued.
+func (fs *GeneralFewerServer) shutdown() {
+	fs.grpcServer.GracefulStop()
+	fs.serverLogger.ServerLogInfo(
+		"method",
+		"GeneralFewerServer_Shutdown",
+		"gRPC server gracefully stopped.",
+	)
+	fs.serverLogger.Close()
+}

--- a/server/internal/server_loggers.go
+++ b/server/internal/server_loggers.go
@@ -1,0 +1,147 @@
+package internal
+
+import (
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+
+
+//************************************************************************************************
+// Definition of a ServerLogger interface that includes common logging operation methods that will
+//   be used across multiple concrete logger types.
+type ServerLogger interface {
+	ServerLogInfo(key, value, message string)
+	ServerLogWarn(key, value, message string)
+	ServerLogError(key, value, message string)
+	Close()
+}
+
+
+
+//*************************************************************************************************
+// Definition of a production-level server activity logger that logs both on the terminal/stdout
+//   and a file.
+type ServerLoggingObjectPROD struct {
+	// Log only current server session activity on standard output
+	terminalLogger   log.Logger
+	// Log all server sessions' history on a file
+	serverFileLogger log.Logger
+	// Log file that the serverFileLogger operates on.  Stored in this field so that
+	//   it can be properly closed when client app is exited.
+	serverLogFile    *os.File
+}
+
+// Constructor function that creates a production-level logger for logging all server activity,
+//   INFO-level and above.
+func NewServerLoggingObjectPROD(serverLogFilename string) *ServerLoggingObjectPROD {
+	// Create terminal logger
+	terminalLogger := log.NewLogfmtLogger(os.Stdout)
+	terminalLogger = level.NewFilter(terminalLogger, level.AllowInfo())
+	terminalLogger = log.With(terminalLogger, "time", log.DefaultTimestampUTC)
+
+	// Add filepath to serverlogs directory to get full server log filepath.
+	serverLogFilename = "fewer_grpc/server/serverlogs/production" + serverLogFilename
+
+	// Create or open the server log file object
+	serverLogFile, err := os.OpenFile(serverLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the logger to operate logging operations on the server log file
+	serverFileLogger := log.NewLogfmtLogger(serverLogFile)
+	serverFileLogger = level.NewFilter(serverFileLogger, level.AllowInfo())
+	serverFileLogger = log.With(serverFileLogger, "time", log.DefaultTimestampUTC)
+
+	return &ServerLoggingObjectPROD{
+		terminalLogger:   terminalLogger,
+		serverFileLogger: serverFileLogger,
+		serverLogFile:    serverLogFile,
+	}
+}
+
+// Method of the ServerLoggingObjectPROD that is used for simultaneously logging
+//   INFO-level activity on both the terminal and server log file.
+func (slop *ServerLoggingObjectPROD) ServerLogInfo(key, value, message string) {
+	go level.Info(slop.terminalLogger).Log(key, value, "message", message)
+	level.Info(slop.serverFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ServerLoggingObjectPROD that is used for simultaneously logging
+//   WARN-level activity on both the terminal and server log file.
+func (slop *ServerLoggingObjectPROD) ServerLogWarn(key, value, message string) {
+	go level.Warn(slop.terminalLogger).Log(key, value, "message", message)
+	level.Warn(slop.serverFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ServerLoggingObjectPROD that is used for simultaneouslu logging
+//   ERROR-level activity on both the terminal and server log file.
+func (slop *ServerLoggingObjectPROD) ServerLogError(key, value, message string) {
+	go level.Error(slop.terminalLogger).Log(key, value, "error", message)
+	level.Error(slop.serverFileLogger).Log(key, value, "error", message)
+}
+
+// Method of the ServerLoggingObjectPROD that is used for closing the server log
+//   file properly when the server is about to shutdown.
+func (slop *ServerLoggingObjectPROD) Close() {
+	slop.serverLogFile.Close()
+}
+
+
+
+//*************************************************************************************************
+// Definition of a development-level server activity logger that logs both on the terminal/stdout
+//   and a file.
+type ServerLoggingObjectDEV struct {
+	// Inherit the ServerLoggingObjectPROD methods, because they also satisfy the 
+	// ServerLogger interface.
+	ServerLoggingObjectPROD
+	// Log only current server session activity on standard output
+	terminalLogger   log.Logger
+	// Log all server sessions' history on a file
+	serverFileLogger log.Logger
+	// Log file that the serverFileLogger operates on.  Stored in this field so that
+	//   it can be properly closed when client app is exited.
+	serverLogFile    *os.File
+}
+
+// Constructor function that creates a production-level logger for logging all server activity,
+//   DEBUG-level and above.
+func NewServerLoggingObjectDEV(serverLogFilename string) *ServerLoggingObjectDEV {
+	// Create terminal logger
+	terminalLogger := log.NewLogfmtLogger(os.Stdout)
+	terminalLogger = level.NewFilter(terminalLogger, level.AllowDebug())
+	terminalLogger = log.With(terminalLogger, "time", log.DefaultTimestampUTC)
+
+	// Add filepath to serverlogs directory to get full server log filepath.
+	serverLogFilename = "fewer_grpc/server/serverlogs/devtest" + serverLogFilename
+
+	// Create or open the server log file object
+	serverLogFile, err := os.OpenFile(serverLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic (err)
+	}
+
+	// Create the logger to operate logging operations on the server log file
+	serverFileLogger := log.NewLogfmtLogger(serverLogFile)
+	serverFileLogger = level.NewFilter(serverFileLogger, level.AllowDebug())
+	serverFileLogger = log.With(serverFileLogger, "time", log.DefaultTimestampUTC)
+
+	return &ServerLoggingObjectDEV{
+		terminalLogger:   terminalLogger,
+		serverFileLogger: serverFileLogger,
+		serverLogFile:    serverLogFile,
+	}
+}
+
+// Method of the ServerLoggingObjectDEV that is used for simultaneously logging
+//   DEBUG-level activity on both the terminal and server log file.
+// This is an operation only used when using a ServerLoggingObjectDEV for a 
+//   ServerLogger.
+func (slod *ServerLoggingObjectDEV) ServerLogDebug(key, value, message string) {
+	go level.Debug(slod.terminalLogger).Log(key, value, "message", message)
+	level.Debug(slod.serverFileLogger).Log(key, value, "message", message)
+}

--- a/server/internal/service_components.go
+++ b/server/internal/service_components.go
@@ -1,0 +1,105 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+
+	pb "github.com/astronomical3/fewer_grpc/fewer"
+)
+
+
+
+//*****************************************************************************************
+//  Definition of the FewerService struct that holds the Fewer Service, and whose methods
+//    act as handlers for client method calls when an instance of this service is 
+//    registered to a general gRPC server.
+type FewerService struct {
+	pb.UnimplementedFewerServiceServer
+	serverLogger ServerLogger
+}
+
+// Constructor function for creating a new instance of the FewerService.
+func NewFewerService(serverLogger ServerLogger) *FewerService {
+	return &FewerService{serverLogger: serverLogger}
+}
+
+// Implementation of the GetAggregatesStream() RPC, which takes in NumberRequest messages,
+//   adds 3 of them together, and every 3rd NumberRequest send, returns a sum (aggregate)
+//   of the last 3 numbers in a NumberResponse.  Of course, this will be a very simple, 
+//   incremental batch processing operation.
+// This is an operation being used for testing whether or not it is possible to have the
+//   server return back to clients FEWER responses than it receives requests (hence the 
+//   name "Fewer Service").  If this operation is successful, it can be assumed that 
+//   bidirectional streaming RPCs are useful for different types of batch processing.
+func (s *FewerService) GetAggregatesStream(stream pb.FewerService_GetAggregatesStreamServer) error {
+	i := 0
+	sum := int32(0)
+	for {
+		// Try to receive a new NumberRequest, req, through the stream.
+		req, err := stream.Recv()
+		// If final request was already received from client...
+		if err == io.EOF {
+			if i % 3 != 0 {
+				// Log final "leftover sum" into server log and return that sum to client if
+				//   number of lefotver number requests is not 3.
+				// Maybe this could be considered a "partial" operation, and could set off
+				//   a warning.  We will simulate such a situation here...
+				s.serverLogger.ServerLogWarn(
+					"rpc",
+					"pb.FewerService_GetAggregatesStream",
+					fmt.Sprintf(
+						"Leftover data not reported in last returned sum.  Actual final sum is %d.  Returning residual sum back to client...",
+						sum,
+					),
+				)
+				stream.Send(&pb.NumberResponse{Result: sum})
+			} else {
+				s.serverLogger.ServerLogInfo(
+					"rpc",
+					"pb.FewerService_GetAggregatesStream",
+					"No leftover data after final sum.  Last sum returned is actual final sum.",
+				)
+			}
+			return nil
+		}
+
+		// If receive error is some other non-nil error...
+		if err != nil {
+			s.serverLogger.ServerLogError(
+				"rpc",
+				"pb.FewerService_GetAggregatesStream",
+				fmt.Sprintf("Could not receive latest request at iteration %d: %v", (i + 1), err),
+			)
+			return err
+		}
+
+		// If no receive error was received, or it is not the end of the stream of messages from the
+		//   client...
+		i++
+		sum += req.InputNum
+		s.serverLogger.ServerLogInfo(
+			"rpc",
+			"pb.FewerService_GetAggregatesStream",
+			fmt.Sprintf("Received input number %d, sum is now %d", req.InputNum, sum),
+		)
+		if i % 3 == 0 {
+			// Every 3 requests the service receives, it returns back the sum of those last 3 numbers
+			//   received, and resets the sum back to 0.
+			// If there is an error during the send, though, error is returned through gRPC runtime.
+			s.serverLogger.ServerLogInfo(
+				"rpc",
+				"pb.FewerService_GetAggregatesStream",
+				"3 input numbers have been added, sending back sum to client...",
+			)
+			if err := stream.Send(&pb.NumberResponse{Result: sum}); err != nil {
+				s.serverLogger.ServerLogError(
+					"rpc",
+					"pb.FewerService_GetAggregatesStream",
+					fmt.Sprintf("Could not send latest sum %d to client", sum),
+				)
+				return err
+			}
+			sum = int32(0)
+		}
+	}
+}


### PR DESCRIPTION
I have created the Server Application for the gRPC Fewer Service.  This application contains the following components:

- **ServerLoggingObjectPROD** and **ServerLoggingObjectDEV** structs: Used for logging all server activity on behalf of the different components of the Server Application.
- **ServerLogger** interface: Used for allowing either a ServerLoggingObjectPROD or ServerLoggingObjectDEV object to be easily created and added into new instances the Server Application during setup, and use the generalized ServerLogInfo(), ServerLogWarn(), ServerLogError(), and Close() methods without the need to always first check that the server logging object is indeed production or development grade.
- **FewerService** struct: Holds the actual gRPC Fewer Service and the logic for its core GetAggregatesStream() RPC operation the clients must call on to use the service.
- **GeneralFewerService** struct: Sets up a general gRPC server object (which is right now a very simple server without any credentials or specialized middleware; might not ever need to do this since it is just an example service).  Also creates a ServerLoggingObjectPROD or ServerLoggingObjectDEV object depending on whether the Server Application instance is specified to be production or development, and registers both the core Fewer Service and a side gRPC Reflection service that testing tools like `grpcurl` can use to get useful information about what the Fewer Service contains.  Lastly, contains logic for listening to OS termination/interruption signals while serving clients, so that the application can gracefully shutdown if ever such a signal were to be issued.
- Main **`fewer_grpc/server/app.go`** file: For main setup of an instance of the Server Application using a CLI, and using flags to the `go run [fewer-grpc/server/]app.go` command to configure the application instance with ease.

-----------------------------------------------------------------------------------

During writing of the server logging objects, I realized that the ServerLoggingObjectDEV was basically using the same definitions of the ServerLogInfo(), ServerLogWarn(), ServerLogError(), and Close() methods (and therefore also satisfying the ServerLogger interface at the same time), so I decided to simply use struct embedding to define the ServerLoggingObjectDEV.  Consequently, that led me to redefine the ClientLoggingObjectDEV in the client logging object definitions by simply embedding the ClientLoggingObjectPROD.  This goes to show how powerful the concepts of structure embedding and generalizations using interfaces can be -- with struct embedding, if a method's definition is not going to be changed from object to object, it need not be rewritten; and with interfaces, calls of methods commonly used across types satisfying the interface need not be specified for one specific concrete type, and re-specified for another type.  

Now that I have been able to understand how methods can be reused and generalized, my next step is to learn how to determine whether or not an object that satisfies an interface is of a certain type, and use that specific type's own unique methods (e.g., for development-level logging objects, use the LogDebug() methods at certain points of the operation).